### PR TITLE
Demote documents from top nav to About + footer

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { ArrowRight } from 'lucide-react'
+import { ArrowRight, FileText } from 'lucide-react'
 
 export const metadata = {
   title: 'About',
@@ -69,6 +69,37 @@ export default function AboutPage() {
           </p>
         </section>
 
+        <section
+          aria-labelledby='downloads-heading'
+          className='mt-12 rounded-2xl border border-navy/10 bg-white/70 p-6 dark:border-cream/10 dark:bg-navy/40'
+        >
+          <h2
+            id='downloads-heading'
+            className='font-code text-xs font-semibold uppercase tracking-[0.22em] text-red'
+          >
+            Downloads
+          </h2>
+          <p className='mt-4 text-base leading-7 text-gray-dark dark:text-tan'>
+            Resume and curriculum vitae are published as versioned artifacts
+            from the About-Me repository. Available as PDF for download and as
+            HTML for inline reading.
+          </p>
+          <div className='mt-5 flex flex-wrap gap-3'>
+            <Link
+              href='/documents'
+              className='inline-flex items-center gap-2 rounded-full border border-navy/20 px-4 py-2 text-sm font-semibold text-navy transition hover:border-navy/40 hover:bg-navy/5 dark:border-cream/20 dark:text-cream dark:hover:border-cream/40 dark:hover:bg-cream/5'
+            >
+              <FileText className='h-4 w-4' /> Resume
+            </Link>
+            <Link
+              href='/documents'
+              className='inline-flex items-center gap-2 rounded-full border border-navy/20 px-4 py-2 text-sm font-semibold text-navy transition hover:border-navy/40 hover:bg-navy/5 dark:border-cream/20 dark:text-cream dark:hover:border-cream/40 dark:hover:bg-cream/5'
+            >
+              <FileText className='h-4 w-4' /> Curriculum Vitae
+            </Link>
+          </div>
+        </section>
+
         <section className='mt-12 flex flex-wrap gap-3'>
           <Link
             href='/projects'
@@ -81,12 +112,6 @@ export default function AboutPage() {
             className='inline-flex items-center gap-2 rounded-full border border-navy/20 px-5 py-3 text-sm font-semibold text-navy transition hover:border-navy/40 hover:bg-navy/5 dark:border-cream/20 dark:text-cream dark:hover:border-cream/40 dark:hover:bg-cream/5'
           >
             Notes
-          </Link>
-          <Link
-            href='/documents'
-            className='inline-flex items-center gap-2 rounded-full border border-navy/20 px-5 py-3 text-sm font-semibold text-navy transition hover:border-navy/40 hover:bg-navy/5 dark:border-cream/20 dark:text-cream dark:hover:border-cream/40 dark:hover:bg-cream/5'
-          >
-            Documents
           </Link>
         </section>
       </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -78,12 +78,6 @@ export function Footer(): JSX.Element {
                 Objects
               </Link>
               <Link
-                href='/documents'
-                className='transition-colors duration-300 hover:text-blue-accent'
-              >
-                Documents
-              </Link>
-              <Link
                 href='/about'
                 className='transition-colors duration-300 hover:text-blue-accent'
               >
@@ -94,6 +88,12 @@ export function Footer(): JSX.Element {
                 className='transition-colors duration-300 hover:text-blue-accent'
               >
                 Contact
+              </Link>
+              <Link
+                href='/documents'
+                className='transition-colors duration-300 hover:text-blue-accent'
+              >
+                Resume / CV
               </Link>
             </nav>
           </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -10,7 +10,6 @@ const navLinks = [
   { title: 'Work', href: '/projects' },
   { title: 'Notes', href: '/notes' },
   { title: 'Objects', href: '/objects' },
-  { title: 'Documents', href: '/documents' },
   { title: 'About', href: '/about' }
 ]
 

--- a/src/tests/expectations/about_page.json
+++ b/src/tests/expectations/about_page.json
@@ -4,7 +4,7 @@
     "Navbar is visible",
     "Main content orients the site as a record of work",
     "Current threads, reading guidance, and background sections are present",
-    "Documents CTA is visible",
+    "Downloads section lists Resume and Curriculum Vitae linking to /documents",
     "No loading errors or placeholders if data is fresh",
     "Footer is visible"
   ],

--- a/src/tests/expectations/home_page.json
+++ b/src/tests/expectations/home_page.json
@@ -1,7 +1,7 @@
 {
   "page": "Home",
   "expectations": [
-    "Navbar is visible with links to Work, Notes, Objects, Documents, and About",
+    "Navbar is visible with links to Work, Notes, Objects, and About",
     "Hero section displays profile image, introduction text, and call-to-action buttons",
     "Stats section shows GitHub language statistics and tool breakdowns",
     "Projects section lists featured projects with cards including titles, descriptions, and links",


### PR DESCRIPTION
## Summary
- Drops Documents from the primary top nav so it isn't framed as one of the five things the site is *for*.
- Adds a Downloads section to the About page with Resume and Curriculum Vitae links.
- Adds a small \`Resume / CV\` link to the footer Pages list for the visitor who already knows they want it.

## Why
The earlier portfolio rewrite framed the site as a field record rather than a sales pitch. Putting Documents in primary navigation cut against that — it reintroduced the most pitch-shaped surface on the site at top-level prominence. Two reach paths (About + footer) are enough for the actual intent:
- *"Tell me more about Brandon"* → About page lands them in a Downloads block alongside the rest of the orientation.
- *"I already know I want the resume"* → footer link, one click from any page.

## What didn't change
- The \`/documents\` route is intact; only the entry points moved.
- The \`/documents\` page itself, the manifest fetch, and the About-Me Pages source are untouched.

## Verification
- \`bun run lint:ts\` ✓
- \`bun run lint:eslint\` ✓ (no new warnings; pre-existing warnings only in untouched files)
- Local dev server: homepage nav reads Work / Notes / Objects / About; About page renders Downloads section above the Work/Notes CTAs; footer Pages list includes \`Resume / CV\` after Contact.
- Test expectation JSON files updated for home and about pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)